### PR TITLE
Build for headless usage

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -15,12 +15,17 @@ IMAGEURL="http://mirror.pnl.gov/fedora/linux/releases/23/Images/armhfp/Fedora-Mi
 BOOTSIZE=100
 ROOTSIZE=1800
 COMPRESS=0
+
 if [[ ! -f settings.conf ]]; then
 	echo "No settings.conf found, using defaults"
 else
 	echo "Using settings.conf"
 	. settings.conf
 fi
+
+# export settings so subshells can access them
+export DISABLE_INITIAL_SETUP
+
 IMAGEFILE=${IMAGEURL##*/}
 IMAGEFILE=${IMAGEFILE%.*}
 echo "BOOTSIZE is $BOOTSIZE MB"
@@ -134,4 +139,3 @@ if [[ $COMPRESS -ne 0 ]]; then
 fi
 
 echo "$IMAGEFILE.img created successfully."
-

--- a/scripts/root/40_add_root_pubkey.sh
+++ b/scripts/root/40_add_root_pubkey.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+[[ -e "$RESOURCEDIR/authorized_keys" ]] || exit 0
+echo "Adding root pubkey..."
+mkdir -p "$MNTDIR/root/.ssh" || exit 1
+cp -f "$RESOURCEDIR/authorized_keys" "$MNTDIR/root/.ssh/authorized_keys" || exit 1
+echo "Setting root key permissions..."
+chmod 700 "$MNTDIR/root/.ssh" || exit 1
+chmod 600 "$MNTDIR/root/.ssh/authorized_keys" || exit 1

--- a/scripts/root/50_disable_initial_setup.sh
+++ b/scripts/root/50_disable_initial_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[[ $DISABLE_INITIAL_SETUP -ne 0 ]] || exit 0
+echo "Disabling initial-setup..."
+rm "$MNTDIR/etc/systemd/system/multi-user.target.wants/initial-setup-text.service" || exit 1

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -1,5 +1,12 @@
 IMAGEURL="http://mirror.pnl.gov/fedora/linux/releases/23/Images/armhfp/Fedora-Minimal-armhfp-23-10-sda.raw.xz"
+
 # size in MB
 BOOTSIZE=100
 ROOTSIZE=1800
+
+# zero remaining space (for better compression)?
 COMPRESS=0
+
+# don't run initial-setup on first boot
+# https://fedoraproject.org/wiki/InitialSetup
+#DISABLE_INITIAL_SETUP=1


### PR DESCRIPTION
This tool works very well for me (thanks!), except that I prefer to SSH into new images and provision them with Ansible, rather than using a display or a serial console to set them up interactively. So this PR adds scripts to (a) enable root login over SSH with an empty password, and (b) disable the initial-setup service, since I don't use it.

Of course, this is hilariously insecure and unusable for most people, so I don't expect you to merge this as-is. But I think it'd be a useful option. Any thoughts on how we should make this opt-in? Maybe a HEADLESS=1 environment variable or something?
